### PR TITLE
fix: cinder_limits_volume_used_gb metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /openstack-database-exporter
+exporter.sh

--- a/internal/collector/cinder/integration_test.go
+++ b/internal/collector/cinder/integration_test.go
@@ -300,4 +300,33 @@ openstack_cinder_volume_type_quota_gigabytes{tenant="proj-002",tenant_id="proj-0
 			t.Fatalf("unexpected per-type quota error: %v", err)
 		}
 	})
+
+	t.Run("usage without explicit quota (issue #92)", func(t *testing.T) {
+		// proj-003 has usage in quota_usages but NO row in quotas table
+		itest.SeedSQL(t, db,
+			`INSERT INTO quota_usages (project_id, resource, in_use, reserved, deleted) VALUES
+			('proj-003', 'gigabytes', 500, 0, 0),
+			('proj-003', 'backup_gigabytes', 30, 0, 0)`,
+		)
+
+		resolver := project.NewResolver(logger, nil, 0)
+		collector := NewLimitsCollector(db, logger, resolver)
+
+		// proj-003 should show usage from quota_usages and default limits (1000)
+		// Also include proj-001 and proj-002 from earlier subtests (shared DB)
+		err := testutil.CollectAndCompare(collector, strings.NewReader(`# HELP openstack_cinder_limits_volume_used_gb limits_volume_used_gb
+# TYPE openstack_cinder_limits_volume_used_gb gauge
+openstack_cinder_limits_volume_used_gb{tenant="proj-001",tenant_id="proj-001"} 250
+openstack_cinder_limits_volume_used_gb{tenant="proj-002",tenant_id="proj-002"} 100
+openstack_cinder_limits_volume_used_gb{tenant="proj-003",tenant_id="proj-003"} 500
+# HELP openstack_cinder_limits_backup_used_gb limits_backup_used_gb
+# TYPE openstack_cinder_limits_backup_used_gb gauge
+openstack_cinder_limits_backup_used_gb{tenant="proj-001",tenant_id="proj-001"} 50
+openstack_cinder_limits_backup_used_gb{tenant="proj-002",tenant_id="proj-002"} 0
+openstack_cinder_limits_backup_used_gb{tenant="proj-003",tenant_id="proj-003"} 30
+`), "openstack_cinder_limits_volume_used_gb", "openstack_cinder_limits_backup_used_gb")
+		if err != nil {
+			t.Fatalf("unexpected error for usage-without-quota: %v", err)
+		}
+	})
 }

--- a/internal/collector/cinder/limits.go
+++ b/internal/collector/cinder/limits.go
@@ -108,10 +108,17 @@ func (c *LimitsCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx := context.Background()
 
-	// Get quota limits from cinder DB
+	// Get quota limits (hard_limit) from quotas table
 	quotaLimits, err := c.queries.GetProjectQuotaLimits(ctx)
 	if err != nil {
 		c.logger.Error("failed to query quota limits", "error", err)
+		return
+	}
+
+	// Get quota usages (in_use) from quota_usages table
+	quotaUsages, err := c.queries.GetProjectQuotaUsages(ctx)
+	if err != nil {
+		c.logger.Error("failed to query quota usages", "error", err)
 		return
 	}
 
@@ -122,7 +129,7 @@ func (c *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	// Build per-project quota data from DB
+	// Build per-project quota limits from quotas table
 	projectQuotas := make(map[string]*projectQuotaInfo)
 	for _, quota := range quotaLimits {
 		pid := quota.ProjectID.String
@@ -134,12 +141,26 @@ func (c *LimitsCollector) Collect(ch chan<- prometheus.Metric) {
 		switch quota.Resource {
 		case "gigabytes":
 			pq.volumeMaxGB = quota.HardLimit.Int32
-			pq.volumeUsedGB = quota.InUse
 			pq.hasVolume = true
 		case "backup_gigabytes":
 			pq.backupMaxGB = quota.HardLimit.Int32
-			pq.backupUsedGB = quota.InUse
 			pq.hasBackup = true
+		}
+	}
+
+	// Overlay usage data from quota_usages table
+	for _, usage := range quotaUsages {
+		pid := usage.ProjectID.String
+		if _, ok := projectQuotas[pid]; !ok {
+			projectQuotas[pid] = &projectQuotaInfo{}
+		}
+		pq := projectQuotas[pid]
+
+		switch usage.Resource.String {
+		case "gigabytes":
+			pq.volumeUsedGB = usage.InUse
+		case "backup_gigabytes":
+			pq.backupUsedGB = usage.InUse
 		}
 	}
 

--- a/internal/collector/cinder/limits_test.go
+++ b/internal/collector/cinder/limits_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func TestLimitsCollector(t *testing.T) {
-	cols := []string{"project_id", "resource", "hard_limit", "in_use"}
+	limitsCols := []string{"project_id", "resource", "hard_limit"}
+	usageCols := []string{"project_id", "resource", "in_use"}
 	vtCols := []string{"id", "name"}
 
 	type limitsTestCase struct {
@@ -31,7 +32,8 @@ func TestLimitsCollector(t *testing.T) {
 		{
 			Name: "successful collection with quota limits",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols)
+				limitsRows := sqlmock.NewRows(limitsCols)
+				usageRows := sqlmock.NewRows(usageCols)
 
 				for _, id := range []string{
 					"0c4e939acacf4376bdcd1129f1a054ad",
@@ -43,11 +45,14 @@ func TestLimitsCollector(t *testing.T) {
 					"5961c443439d4fcebe42643723755e9d",
 					"fdb8424c4e4f4c0ba32c52e2de3bd80e",
 				} {
-					rows.AddRow(id, "gigabytes", 1000, 0)
-					rows.AddRow(id, "backup_gigabytes", 1000, 0)
+					limitsRows.AddRow(id, "gigabytes", 1000)
+					limitsRows.AddRow(id, "backup_gigabytes", 1000)
+					usageRows.AddRow(id, "gigabytes", 0)
+					usageRows.AddRow(id, "backup_gigabytes", 0)
 				}
 
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
 				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
 			},
 			ExpectedMetrics: `# HELP openstack_cinder_limits_backup_max_gb limits_backup_max_gb
@@ -95,8 +100,8 @@ openstack_cinder_limits_volume_used_gb{tenant="fdb8424c4e4f4c0ba32c52e2de3bd80e"
 		{
 			Name: "empty results",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(sqlmock.NewRows(limitsCols))
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(sqlmock.NewRows(usageCols))
 				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
 			},
 			ExpectedMetrics: "",
@@ -104,10 +109,14 @@ openstack_cinder_limits_volume_used_gb{tenant="fdb8424c4e4f4c0ba32c52e2de3bd80e"
 		{
 			Name: "single project with non-zero usage",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols).
-					AddRow("proj-abc", "gigabytes", 500, 250).
-					AddRow("proj-abc", "backup_gigabytes", 200, 75)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				limitsRows := sqlmock.NewRows(limitsCols).
+					AddRow("proj-abc", "gigabytes", 500).
+					AddRow("proj-abc", "backup_gigabytes", 200)
+				usageRows := sqlmock.NewRows(usageCols).
+					AddRow("proj-abc", "gigabytes", 250).
+					AddRow("proj-abc", "backup_gigabytes", 75)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
 				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
 			},
 			ExpectedMetrics: `# HELP openstack_cinder_limits_backup_max_gb limits_backup_max_gb
@@ -127,9 +136,12 @@ openstack_cinder_limits_volume_used_gb{tenant="proj-abc",tenant_id="proj-abc"} 2
 		{
 			Name: "only gigabytes resource (no backup) - defaults applied",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols).
-					AddRow("proj-1", "gigabytes", 1000, 100)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				limitsRows := sqlmock.NewRows(limitsCols).
+					AddRow("proj-1", "gigabytes", 1000)
+				usageRows := sqlmock.NewRows(usageCols).
+					AddRow("proj-1", "gigabytes", 100)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
 				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
 			},
 			ExpectedMetrics: `# HELP openstack_cinder_limits_backup_max_gb limits_backup_max_gb
@@ -149,10 +161,14 @@ openstack_cinder_limits_volume_used_gb{tenant="proj-1",tenant_id="proj-1"} 100
 		{
 			Name: "volume type quotas default to -1 when no per-type quota exists",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols).
-					AddRow("proj-1", "gigabytes", 1000, 50).
-					AddRow("proj-1", "backup_gigabytes", 500, 10)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				limitsRows := sqlmock.NewRows(limitsCols).
+					AddRow("proj-1", "gigabytes", 1000).
+					AddRow("proj-1", "backup_gigabytes", 500)
+				usageRows := sqlmock.NewRows(usageCols).
+					AddRow("proj-1", "gigabytes", 50).
+					AddRow("proj-1", "backup_gigabytes", 10)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
 				vtRows := sqlmock.NewRows(vtCols).
 					AddRow("type-1", "standard").
 					AddRow("type-2", "__DEFAULT__")
@@ -179,11 +195,15 @@ openstack_cinder_volume_type_quota_gigabytes{tenant="proj-1",tenant_id="proj-1",
 		{
 			Name: "per-volume-type quota picked up from gigabytes_ resource",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols).
-					AddRow("proj-1", "gigabytes", 1000, 50).
-					AddRow("proj-1", "backup_gigabytes", 500, 10).
-					AddRow("proj-1", "gigabytes_standard", 300, 0)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				limitsRows := sqlmock.NewRows(limitsCols).
+					AddRow("proj-1", "gigabytes", 1000).
+					AddRow("proj-1", "backup_gigabytes", 500).
+					AddRow("proj-1", "gigabytes_standard", 300)
+				usageRows := sqlmock.NewRows(usageCols).
+					AddRow("proj-1", "gigabytes", 50).
+					AddRow("proj-1", "backup_gigabytes", 10)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
 				vtRows := sqlmock.NewRows(vtCols).
 					AddRow("type-1", "standard").
 					AddRow("type-2", "__DEFAULT__")
@@ -208,11 +228,37 @@ openstack_cinder_volume_type_quota_gigabytes{tenant="proj-1",tenant_id="proj-1",
 `,
 		},
 		{
+			Name: "usage without explicit quota (issue #92)",
+			SetupMock: func(mock sqlmock.Sqlmock) {
+				// Project has NO row in quotas table but DOES have usage in quota_usages
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(sqlmock.NewRows(limitsCols))
+				usageRows := sqlmock.NewRows(usageCols).
+					AddRow("proj-no-quota", "gigabytes", 150).
+					AddRow("proj-no-quota", "backup_gigabytes", 25)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(usageRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
+			},
+			ExpectedMetrics: `# HELP openstack_cinder_limits_backup_max_gb limits_backup_max_gb
+# TYPE openstack_cinder_limits_backup_max_gb gauge
+openstack_cinder_limits_backup_max_gb{tenant="proj-no-quota",tenant_id="proj-no-quota"} 1000
+# HELP openstack_cinder_limits_backup_used_gb limits_backup_used_gb
+# TYPE openstack_cinder_limits_backup_used_gb gauge
+openstack_cinder_limits_backup_used_gb{tenant="proj-no-quota",tenant_id="proj-no-quota"} 25
+# HELP openstack_cinder_limits_volume_max_gb limits_volume_max_gb
+# TYPE openstack_cinder_limits_volume_max_gb gauge
+openstack_cinder_limits_volume_max_gb{tenant="proj-no-quota",tenant_id="proj-no-quota"} 1000
+# HELP openstack_cinder_limits_volume_used_gb limits_volume_used_gb
+# TYPE openstack_cinder_limits_volume_used_gb gauge
+openstack_cinder_limits_volume_used_gb{tenant="proj-no-quota",tenant_id="proj-no-quota"} 150
+`,
+		},
+		{
 			Name: "null project_id",
 			SetupMock: func(mock sqlmock.Sqlmock) {
-				rows := sqlmock.NewRows(cols).
-					AddRow(nil, "gigabytes", 1000, 0)
-				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(rows)
+				limitsRows := sqlmock.NewRows(limitsCols).
+					AddRow(nil, "gigabytes", 1000)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaLimits)).WillReturnRows(limitsRows)
+				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetProjectQuotaUsages)).WillReturnRows(sqlmock.NewRows(usageCols))
 				mock.ExpectQuery(regexp.QuoteMeta(cinderdb.GetVolumeTypes)).WillReturnRows(sqlmock.NewRows(vtCols))
 			},
 			ExpectedMetrics: `# HELP openstack_cinder_limits_backup_max_gb limits_backup_max_gb

--- a/internal/db/cinder/queries.sql.go
+++ b/internal/db/cinder/queries.sql.go
@@ -194,13 +194,9 @@ const GetProjectQuotaLimits = `-- name: GetProjectQuotaLimits :many
 SELECT
     q.project_id,
     q.resource,
-    q.hard_limit,
-    COALESCE(qu.in_use, 0) as in_use
+    q.hard_limit
 FROM
     quotas q
-    LEFT JOIN quota_usages qu ON q.project_id = qu.project_id
-        AND q.resource = qu.resource
-        AND qu.deleted = 0
 WHERE
     q.deleted = 0
     AND (q.resource IN ('gigabytes', 'backup_gigabytes') OR q.resource LIKE 'gigabytes\_%')
@@ -210,7 +206,6 @@ type GetProjectQuotaLimitsRow struct {
 	ProjectID sql.NullString
 	Resource  string
 	HardLimit sql.NullInt32
-	InUse     int32
 }
 
 func (q *Queries) GetProjectQuotaLimits(ctx context.Context) ([]GetProjectQuotaLimitsRow, error) {
@@ -222,12 +217,48 @@ func (q *Queries) GetProjectQuotaLimits(ctx context.Context) ([]GetProjectQuotaL
 	var items []GetProjectQuotaLimitsRow
 	for rows.Next() {
 		var i GetProjectQuotaLimitsRow
-		if err := rows.Scan(
-			&i.ProjectID,
-			&i.Resource,
-			&i.HardLimit,
-			&i.InUse,
-		); err != nil {
+		if err := rows.Scan(&i.ProjectID, &i.Resource, &i.HardLimit); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const GetProjectQuotaUsages = `-- name: GetProjectQuotaUsages :many
+SELECT
+    qu.project_id,
+    qu.resource,
+    qu.in_use
+FROM
+    quota_usages qu
+WHERE
+    qu.deleted = 0
+    AND qu.resource IN ('gigabytes', 'backup_gigabytes')
+`
+
+type GetProjectQuotaUsagesRow struct {
+	ProjectID sql.NullString
+	Resource  sql.NullString
+	InUse     int32
+}
+
+func (q *Queries) GetProjectQuotaUsages(ctx context.Context) ([]GetProjectQuotaUsagesRow, error) {
+	rows, err := q.db.QueryContext(ctx, GetProjectQuotaUsages)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetProjectQuotaUsagesRow
+	for rows.Next() {
+		var i GetProjectQuotaUsagesRow
+		if err := rows.Scan(&i.ProjectID, &i.Resource, &i.InUse); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/sql/cinder/queries.sql
+++ b/sql/cinder/queries.sql
@@ -22,16 +22,23 @@ WHERE
 SELECT
     q.project_id,
     q.resource,
-    q.hard_limit,
-    COALESCE(qu.in_use, 0) as in_use
+    q.hard_limit
 FROM
     quotas q
-    LEFT JOIN quota_usages qu ON q.project_id = qu.project_id
-        AND q.resource = qu.resource
-        AND qu.deleted = 0
 WHERE
     q.deleted = 0
     AND (q.resource IN ('gigabytes', 'backup_gigabytes') OR q.resource LIKE 'gigabytes\_%');
+
+-- name: GetProjectQuotaUsages :many
+SELECT
+    qu.project_id,
+    qu.resource,
+    qu.in_use
+FROM
+    quota_usages qu
+WHERE
+    qu.deleted = 0
+    AND qu.resource IN ('gigabytes', 'backup_gigabytes');
 
 -- name: GetAllProjectQuotas :many
 SELECT


### PR DESCRIPTION
Fixes: https://github.com/vexxhost/openstack_database_exporter/issues/92

Limits → read hard_limit from quotas (which only exists when explicitly set)
Usage → read in_use directly from quota_usages (which always exists when resources are consumed)
