### PR TITLE
fix(cinder): remove forced volumes service_uuid index

### DIFF
--- a/internal/db/cinder/queries.sql.go
+++ b/internal/db/cinder/queries.sql.go
@@ -135,12 +135,11 @@ SELECT
     vt.name as volume_type,
     va.instance_uuid as server_id
 FROM
-    volumes v USE INDEX (volumes_service_uuid_idx)
+    volumes v
     LEFT JOIN volume_types vt ON v.volume_type_id = vt.id
     LEFT JOIN volume_attachment va ON v.id = va.volume_id AND va.deleted = 0
 WHERE
-    (v.service_uuid IS NULL OR v.service_uuid IS NOT NULL)
-    AND v.deleted = 0
+    v.deleted = 0
 `
 
 type GetAllVolumesRow struct {

--- a/sql/cinder/indexes.sql
+++ b/sql/cinder/indexes.sql
@@ -3,8 +3,7 @@
 -- For the quotas query
 CREATE INDEX IF NOT EXISTS ix_quotas_deleted_resource ON quotas(deleted, resource);
 
--- For the volumes query (USE INDEX hint in query requires this)
-CREATE INDEX IF NOT EXISTS volumes_service_uuid_idx ON volumes(service_uuid);
+-- For the volumes query
 CREATE INDEX IF NOT EXISTS ix_volumes_deleted ON volumes(deleted);
 CREATE INDEX IF NOT EXISTS ix_volume_types_id_deleted ON volume_types(id, deleted);
 CREATE INDEX IF NOT EXISTS ix_volume_attachment_volume_id_deleted ON volume_attachment(volume_id, deleted);

--- a/sql/cinder/queries.sql
+++ b/sql/cinder/queries.sql
@@ -84,9 +84,8 @@ SELECT
     vt.name as volume_type,
     va.instance_uuid as server_id
 FROM
-    volumes v USE INDEX (volumes_service_uuid_idx)
+    volumes v
     LEFT JOIN volume_types vt ON v.volume_type_id = vt.id
     LEFT JOIN volume_attachment va ON v.id = va.volume_id AND va.deleted = 0
 WHERE
-    (v.service_uuid IS NULL OR v.service_uuid IS NOT NULL)
-    AND v.deleted = 0;
+    v.deleted = 0;


### PR DESCRIPTION
## Summary

- Remove the forced `volumes_service_uuid_idx` hint from the Cinder `GetAllVolumes` query.
- Remove the tautological `service_uuid` predicate so the query filters directly on `v.deleted = 0`.
- Remove the unused helper index entry for `volumes_service_uuid_idx`.

## Context

The current query effectively filters active volumes by `deleted`, but forces an index that starts with `service_uuid`. Since the `service_uuid` predicate does not narrow the result set, the hint can prevent MySQL from selecting a better `deleted`-leading plan on large `volumes` tables.

## Testing

- `go test ./internal/collector/cinder`
- `go test ./...`